### PR TITLE
GPLv2 Combination Exception for the Apache 2 License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -199,3 +199,14 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+--- Exceptions to the Apache 2.0 License ---
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision
+(Section 3), the indemnity provision (Section 9) or other Section of the
+License conflicts with the conditions of the GPLv2, you may retroactively
+and prospectively choose to deem waived or otherwise exclude such Section(s)
+of the License, but only in their entirety and only with respect to the
+Combined Software.


### PR DESCRIPTION
Add an exception to the Apache 2 licence to make it explicitly
compatible with GPLv2.