### PR TITLE
Set column size on types with variable size

### DIFF
--- a/src/odbc/PreparedStatement.cpp
+++ b/src/odbc/PreparedStatement.cpp
@@ -154,10 +154,16 @@ void PreparedStatement::setCString(unsigned short paramIndex, const char* s,
     std::size_t len)
 {
     verifyValidParamIndex(paramIndex);
+    ParameterData& pd = parameterData_[paramIndex - 1];
     if (s == nullptr)
-        parameterData_[paramIndex - 1].setNull(SQL_C_CHAR);
+    {
+        pd.setNull(SQL_C_CHAR);
+    }
     else
-        parameterData_[paramIndex - 1].setValue(SQL_C_CHAR, s, len);
+    {
+        pd.setValue(SQL_C_CHAR, s, len);
+        pd.setColumnSize(len);
+    }
 }
 //------------------------------------------------------------------------------
 void PreparedStatement::setNString(unsigned short paramIndex,
@@ -182,11 +188,16 @@ void PreparedStatement::setNCString(unsigned short paramIndex,
     const char16_t* s, std::size_t len)
 {
     verifyValidParamIndex(paramIndex);
+    ParameterData& pd = parameterData_[paramIndex - 1];
     if (s == nullptr)
-        parameterData_[paramIndex - 1].setNull(SQL_C_WCHAR);
+    {
+        pd.setNull(SQL_C_WCHAR);
+    }
     else
-        parameterData_[paramIndex - 1].setValue(
-            SQL_C_WCHAR, s, len*sizeof(char16_t));
+    {
+        pd.setValue(SQL_C_WCHAR, s, len*sizeof(char16_t));
+        pd.setColumnSize(len);
+    }
 }
 //------------------------------------------------------------------------------
 void PreparedStatement::setBinary(unsigned short paramIndex,
@@ -202,10 +213,16 @@ void PreparedStatement::setBytes(unsigned short paramIndex, const void* data,
     size_t size)
 {
     verifyValidParamIndex(paramIndex);
+    ParameterData& pd = parameterData_[paramIndex - 1];
     if (data == nullptr)
-        parameterData_[paramIndex - 1].setNull(SQL_C_BINARY);
+    {
+        pd.setNull(SQL_C_BINARY);
+    }
     else
-        parameterData_[paramIndex - 1].setValue(SQL_C_BINARY, data, size);
+    {
+        pd.setValue(SQL_C_BINARY, data, size);
+        pd.setColumnSize(size);
+    }
 }
 //------------------------------------------------------------------------------
 void PreparedStatement::setDate(unsigned short paramIndex, const Date& value)

--- a/src/odbc/internal/Batch.cpp
+++ b/src/odbc/internal/Batch.cpp
@@ -323,6 +323,13 @@ void Batch::checkAndCompleteValueTypes()
                 param.getColumnSize() << ", " << param.getDecimalDigits() <<
                 ").");
         }
+
+        // Update column size for types with variable size
+        if (TypeInfo::getSizeOfValueFromValueType(param.getValueType()) == 0)
+        {
+            valTypeInfo.columnSize =
+                max(valTypeInfo.columnSize, param.getColumnSize());
+        }
     }
 }
 //------------------------------------------------------------------------------

--- a/src/odbc/internal/Batch.h
+++ b/src/odbc/internal/Batch.h
@@ -178,8 +178,8 @@ private:
     struct ValueTypeInfo
     {
         std::int16_t type;
-        std::uint8_t columnSize;
-        std::uint8_t decimalDigits;
+        std::size_t columnSize;
+        std::int16_t decimalDigits;
     };
 
 private:

--- a/src/odbc/internal/ParameterData.h
+++ b/src/odbc/internal/ParameterData.h
@@ -119,7 +119,7 @@ public:
      *
      * @return  The column size.
      */
-    std::uint8_t getColumnSize() const { return columnSize_; }
+    std::size_t getColumnSize() const { return columnSize_; }
 
     /**
      * Sets the column size of this parameter. If the parameter type is
@@ -132,7 +132,7 @@ public:
      *
      * @param value  The column size.
      */
-    void setColumnSize(std::uint8_t value) { columnSize_ = value; }
+    void setColumnSize(std::size_t value) { columnSize_ = value; }
 
     /**
      * Returns the number of decimal digits of this parameter. If the parameter
@@ -143,7 +143,7 @@ public:
      *
      * @return  The number of decimal digits.
      */
-    std::uint8_t getDecimalDigits() const { return decimalDigits_; }
+    std::int16_t getDecimalDigits() const { return decimalDigits_; }
 
     /**
      * Sets the number of decimal digits of this parameter. If the parameter
@@ -154,7 +154,7 @@ public:
      *
      * @param value  The number of decimal digits.
      */
-    void setDecimalDigits(std::uint8_t value) { decimalDigits_ = value; }
+    void setDecimalDigits(std::int16_t value) { decimalDigits_ = value; }
 
     /**
      * Checks whether the value is NULL.
@@ -265,8 +265,8 @@ private:
     //    NORMAL_HEAP_OWNING or NORMAL_HEAP_NOT_OWNING
     State state_;
     std::int16_t valueType_;
-    std::uint8_t columnSize_;
-    std::uint8_t decimalDigits_;
+    std::size_t columnSize_;
+    std::int16_t decimalDigits_;
     std::size_t size_;
     union
     {


### PR DESCRIPTION
On SQLBindParameter calls we set the column size parameter to 0 when
binding data with variable size.

Microsoft SQL Server rejected those attempts with an HY104 error.

Therefore, we changed the behavior for types with variable size to set
the column size to the length of the data.