### PR TITLE
Use SQLGetDiagRecA instead of SQLGetDiagRec

### DIFF
--- a/src/odbc/Exception.cpp
+++ b/src/odbc/Exception.cpp
@@ -13,7 +13,7 @@ bool appendRecord(short handleType, void* handle, SQLSMALLINT recNumber,
     SQLINTEGER nativeError;
     SQLCHAR messageText[2048];
     SQLSMALLINT textLength;
-    SQLRETURN rc = SQLGetDiagRec(handleType, handle, recNumber, sqlState,
+    SQLRETURN rc = SQLGetDiagRecA(handleType, handle, recNumber, sqlState,
         &nativeError, messageText, sizeof(messageText)/sizeof(SQLCHAR),
         &textLength);
     switch (rc)


### PR DESCRIPTION
As the buffer for the error message has type SQLCHAR, we need to call
SQLGetDiagRecA instead of SQLGetDiagRec.