### PR TITLE
Add move constructor and move assignment operator to Reference class

### DIFF
--- a/src/odbc/RefCounted.h
+++ b/src/odbc/RefCounted.h
@@ -81,6 +81,16 @@ public:
     Reference(const Reference<T>& other) { set_(other.ptr_); }
 
     /**
+     * Move constructor moving an existing reference.
+     *
+     * @param other  Another reference
+     */
+    Reference(Reference<T>&& other) noexcept : ptr_(other.ptr_)
+    {
+        other.ptr_ = nullptr;
+    }
+
+    /**
      * Destructor decreasing the reference-count of the managed object.
      */
     ~Reference() { free_(); }
@@ -93,10 +103,27 @@ public:
      * the reference-count of the newly managed object is incremented.
      *
      * @param other  Another reference.
+     * @return       Returns a reference to this object.
      */
     Reference& operator=(const Reference<T>& other)
     {
         reset_(other.ptr_);
+        return *this;
+    }
+
+    /**
+     * Move-assigns another reference to this reference.
+     *
+     * The reference-count of the currently held object is decreased.
+     *
+     * @param other  Another reference.
+     * @return       Returns a reference to this object.
+     */
+    Reference& operator=(Reference<T>&& other) noexcept
+    {
+        free_();
+        ptr_ = other.ptr_;
+        other.ptr_ = nullptr;
         return *this;
     }
 


### PR DESCRIPTION
This pull request should resolve some Coverity Scan warnings mentioned in https://github.com/OSGeo/gdal/issues/5568.