### PR TITLE
Resolve some compiler warnings

### DIFF
--- a/src/odbc/Exception.h
+++ b/src/odbc/Exception.h
@@ -48,7 +48,7 @@ public:
      *
      * @return  Returns a description of the error that occurred.
      */
-    virtual const char* what() const noexcept;
+    const char* what() const noexcept override;
 
 private:
     std::string msg_;

--- a/src/odbc/RefCounted.h
+++ b/src/odbc/RefCounted.h
@@ -56,7 +56,7 @@ public:
     /**
      * Constructs a NULL reference.
      */
-    Reference() : ptr_(0) {}
+    Reference() : ptr_(nullptr) {}
 
     /**
      * Constructs a reference to a given reference-counted object.
@@ -133,7 +133,7 @@ public:
      * @return  Returns true if this reference manages an object, false
      *          otherwise.
      */
-    bool isNull() const { return ptr_ == 0; }
+    bool isNull() const { return ptr_ == nullptr; }
 
     /**
      * Returns a reference to the managed object.
@@ -183,7 +183,7 @@ public:
      * Decreases the reference-count of the managed object and does not
      * reference it anymore.
      */
-    void reset() { reset_(0); }
+    void reset() { reset_(nullptr); }
 
     /**
      * Releases the currently managed object and manages a new object.

--- a/src/odbc/Types.h
+++ b/src/odbc/Types.h
@@ -318,7 +318,7 @@ public:
      *
      * @return  Returns the unscaled value of this decimal number.
      */
-    const char* unscaledValue() const { return value_.c_str(); };
+    const char* unscaledValue() const { return value_.c_str(); }
 
     /**
      * Returns a string representation of this number.


### PR DESCRIPTION
This PR resolves the following compiler warnings:

../odbc/Types.h:321:65: warning: extra ';' after member function definition [-Wextra-semi]
    const char* unscaledValue() const { return value_.c_str(); };
                                                                                              ^
../odbc/Exception.h:51:25: warning: 'what' overrides a member function but is not marked 'override' [-Wsuggest-override]
    virtual const char* what() const noexcept;
                        ^
../SDKs/MacOSX12.3.sdk/usr/include/c++/v1/exception:106:25: note: overridden virtual function is here
    virtual const char* what() const _NOEXCEPT;
                        ^
../odbc/RefCounted.h:59:24: warning: zero as null pointer constant [-Wzero-as-null-pointer-constant]
    Reference() : ptr_(0) {}
                       ^  nullptr
../odbc/RefCounted.h:136:42: warning: zero as null pointer constant [-Wzero-as-null-pointer-constant]
    bool isNull() const { return ptr_ == 0; }
                                         ^  nullptr